### PR TITLE
Improve flock behavior

### DIFF
--- a/Assets/Prefabs/BasicGame.prefab
+++ b/Assets/Prefabs/BasicGame.prefab
@@ -277,10 +277,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5149257497492575278, guid: e31a72debb4474f8c9c6656dba5262d2, type: 3}
-      propertyPath: neighborhoodRadius
-      value: 5
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e31a72debb4474f8c9c6656dba5262d2, type: 3}
 --- !u!4 &6870282323264096202 stripped

--- a/Assets/Prefabs/FlockManager.prefab
+++ b/Assets/Prefabs/FlockManager.prefab
@@ -44,19 +44,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 98cafa4bb020f2d49a95d039807f251d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  creaturePrefab: {fileID: 8746415100772626246, guid: 39ff5f30d5d78e647bec365e10651318, type: 3}
-  numCreature: 20
-  autoAdjustGoalPos: 0
-  applyMovementLimits: 0
-  moveLimits: {x: 5, y: 0, z: 5}
-  minSpeed: 2.5
-  maxSpeed: 2.5
-  neighbourDistance: 5
-  rotationSpeed: 2.5
-  goalPos: {x: 10, y: 0, z: 10}
-  allCreatures: []
-  flockManagerDirectionUpdateFrequency: 0.1
+  neighborhoodRadius: 2.54
+  desiredAvoidDistance: 5
+  avoidWeight: 0.5
+  randomWalkDistance: 5
+  randomWalkUpdateFrequency: 3
+  avoidTags:
+  - Player
+  - Dog
+  - CompletedGoalBox
   flockUpdateFrequency: 0.1
-  gizmoYOffset: 0.5
-  gizmoSphereRadius: 1
-  uuid: 
+  goalPos: {x: 10, y: 0, z: 10}
+  goalPosObject: {fileID: 0}
+  goalPosOverride: 0

--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -179,7 +179,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3185466308537193190, guid: f36ea468ab95247c99fc4932a78b3c69, type: 3}
       propertyPath: neighborhoodRadius
-      value: 10
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3185466308537193190, guid: f36ea468ab95247c99fc4932a78b3c69, type: 3}
+      propertyPath: desiredAvoidDistance
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3185466308537193190, guid: f36ea468ab95247c99fc4932a78b3c69, type: 3}
+      propertyPath: avoidTags.Array.data[2]
+      value: CompletedGoalBox
       objectReference: {fileID: 0}
     - target: {fileID: 3185466308537193191, guid: f36ea468ab95247c99fc4932a78b3c69, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Prefabs/sheep.prefab
+++ b/Assets/Prefabs/sheep.prefab
@@ -60,7 +60,7 @@ NavMeshAgent:
   m_Enabled: 1
   m_AgentTypeID: -1372625422
   m_Radius: 0.5
-  m_Speed: 3.5
+  m_Speed: 7
   m_Acceleration: 8
   avoidancePriority: 50
   m_AngularSpeed: 120

--- a/Assets/Scripts/FlockManager.cs
+++ b/Assets/Scripts/FlockManager.cs
@@ -5,19 +5,18 @@ using UnityEngine;
 public class FlockManager : MonoBehaviour {
 
     [Header("Flock Settings")]
-    [Range(0.0f, 5.0f)] public float minSpeed = 2.5f;
-    [Range(0.0f, 50.0f)] public float maxSpeed = 2.5f;
-    [Range(1.0f, 5.0f)] public float rotationSpeed = 2.5f;
     [Range(1.0f, 10.0f)] public float neighborhoodRadius = 1.7f;
     [Tooltip("How far the flock will try to stay from the player")]
     public float desiredAvoidDistance = 5.0f;
-    [Tooltip("When idle, how far away the sheep will try to talk")]
+    // How much weight will be given to avoidance when an avoid object is nearby. Between 0.0 and 1.0
+    [Range(0.0f, 1.0f)]
+    public float avoidWeight = 0.3f;
+    [Tooltip("When idle, how far away the sheep will try to walk")]
     public float randomWalkDistance = 5.0f;
     [Tooltip("How frequently the sheep will change their idle position")]
     public float randomWalkUpdateFrequency = 3.0f;
     [Tooltip("Tags that the flock members will try to avoid")]
     public string[] avoidTags = new string[] { "Player", "Dog" };
-
 
     [Header("Advanced Settings")]
     [Tooltip("How frequently the Flock component applies flock rules. Between 0.0 and 1.0")]
@@ -29,11 +28,4 @@ public class FlockManager : MonoBehaviour {
     [Tooltip("Hardcoded target to follow, overrides other settings including goal position")]
     public GameObject goalPosObject = null;
     public bool goalPosOverride = false;
-
-
-    [Header("Deprecated")]
-    [Tooltip("moveLimits is deprecated don't use it")]
-    public Vector3 moveLimits = new Vector3(5.0f, 5.0f, 5.0f);
-    [Tooltip("flag to applyMoveLimits")]
-    public bool applyMovementLimits = false;
 }

--- a/Assets/Scripts/GoalBoxController.cs
+++ b/Assets/Scripts/GoalBoxController.cs
@@ -59,12 +59,10 @@ public class GoalBoxController : MonoBehaviour
             // get the transform of the other
             GameObject otherGo = sheep;
             Vector3 disp = transform.position - otherGo.transform.position;
-            Debug.Log("Distance to goal: " + disp.magnitude);
-            if (disp.magnitude < GoalDistanceThreshold) {
-                // Destroy(other.gameObject);
-                UnityEngine.AI.NavMeshAgent agent = sheep.GetComponent<UnityEngine.AI.NavMeshAgent>();
-                agent.SetDestination(transform.position);
-                sheep.GetComponent<Flock>().enabled = false;
+            if (!isGoalComplete) {
+                Flock flock = sheep.GetComponent<Flock>();
+                flock.SetGoalPos(transform.position);
+                flock.enabled = false;
                 destroyedCount += 1;
                 sheep.GetComponent<AudioSource>().Play();
                 doneSheep.Add(otherGo);

--- a/Assets/Scripts/GoalBoxController.cs
+++ b/Assets/Scripts/GoalBoxController.cs
@@ -77,6 +77,7 @@ public class GoalBoxController : MonoBehaviour
         {
             if (!winAnimationPlayed)
             {
+                gameObject.tag = "CompletedGoalBox";
                 gateAnimator.Play("CloseGateDoors");
                 goalSphere.SetActive(false);
                 sheepRemainingText.text = "";

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -7,6 +7,7 @@ TagManager:
   - Dog
   - Ground
   - GoalBox
+  - CompletedGoalBox
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Improves several aspects of flocking behavior:

- Adds a weight parameter to balance how much sheep try to flock while being repelled (previously no flocking would occur when sheep were repelled)
- Fixes a bug where sheep goal would be calculated incorrectly if they had neighbors without an enabled `Flock` component
- Adds completed goal boxes as a repel object for flocks so sheep try to exit 
- Goal boxes now will not accept any more sheep after their capacity is met
- Removes unused flocking code